### PR TITLE
Update app.json application name to 30 characters

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "Asp.NetCore Web App With PostgreSQL",
+  "name": "Asp.NetCore Web App PostgreSQL",
   "description": "Asp.Net website using Asp.Net Core",
   "website": "http://www.softtrends.com/",
   "repository": "https://github.com/heroku-softtrends/dotnetcore.postgress.sample",


### PR DESCRIPTION
Heroku has a fixed limit of 30 characters for the application name. This commit updates the name to 30 characters without losing context to fix issue #1 